### PR TITLE
add 'warmupTimeout' setting

### DIFF
--- a/lib/Suite.js
+++ b/lib/Suite.js
@@ -16,6 +16,10 @@ function Suite( clientOpts, props ){
   if( !this.props.hasOwnProperty('index') ){
     this.props.index = 'testindex-' + randomstring.generate(7).toLowerCase();
   }
+
+  // time to wait between actions & asserts to ensure the shard has updated.
+  // particularly useful when retrieving newly generated mappings.
+  this.warmupTimeout = 500;
 }
 
 Suite.prototype.action = function( action ){
@@ -56,14 +60,14 @@ Suite.prototype.run = function( cb ){
       if( err ) throw new Error( err );
       async.series( self.actions, function(){
         self.refresh( function(){
-          async.series( self.asserts, function(){
+          setTimeout( async.series( self.asserts, function(){
             self.delete( function(){
               self.client.close();
               if( 'function' === typeof cb ){
                 cb();
               }
             });
-          });
+          }), self.warmupTimeout );
         });
       });
     });


### PR DESCRIPTION
time to wait between actions & asserts to ensure the shard has updated.
particularly useful when retrieving newly generated mappings.