### PR TITLE
Use supported elasticsearch client

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ var suite = new elastictest.Suite();
 
 var doc = {
   index: suite.props.index,
-  type: 'mytype',
   id: '1',
   body: {
     foo: 'bar'
@@ -29,7 +28,6 @@ suite.action( function( done ){
 suite.assert( function( done ){
   suite.client.count({
     index: doc.index,
-    type: doc.type
   }, function( err, res ){
     t.equal( res.count, 1, 'record count' );
     done();
@@ -71,7 +69,6 @@ You **must** call `done()` when your async operations are complete. You may add 
 suite.assert( function( done ){
   suite.client.count({
     index: doc.index,
-    type: doc.type
   }, function( err, res ){
     t.equal( res.count, 1, 'record count' );
     done();

--- a/lib/Suite.js
+++ b/lib/Suite.js
@@ -1,7 +1,7 @@
 
 const _ = require('lodash');
 const randomstring = require('randomstring');
-const elasticsearch = require('elasticsearch');
+const elasticsearch = require('@elastic/elasticsearch');
 const async = require('async');
 
 function Suite( clientOpts, props ){
@@ -9,7 +9,7 @@ function Suite( clientOpts, props ){
   this.asserts = [];
   this.client = null;
   this.clientOpts = clientOpts && clone( clientOpts ) || {
-    host: 'localhost:9200',
+    node: 'http://localhost:9200',
     keepAlive: true
   };
   this.props = props || {};

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "async": "^3.1.0",
-    "elasticsearch": "^16.5.0",
+    "@elastic/elasticsearch": "^7.17.0",
     "lodash": "^4.17.15",
     "randomstring": "^1.1.5"
   }

--- a/test/custom_schema.js
+++ b/test/custom_schema.js
@@ -21,7 +21,7 @@ module.exports.tests.custom_schema = function(test, common) {
         index: suite.props.index,
         type: '_doc'
       }, function( err, res ){
-        t.deepEqual( res[suite.props.index].mappings, custom_schema.mappings, 'mappings set' );
+        t.deepEqual( res.body[suite.props.index].mappings, custom_schema.mappings, 'mappings set' );
         done();
       });
     });
@@ -39,7 +39,7 @@ module.exports.tests.custom_schema = function(test, common) {
       suite.client.indices.getSettings({
         index: suite.props.index
       }, function( err, res ){
-        t.deepEqual( res[suite.props.index].settings.index_concurrency, custom_schema.settings.index_concurrency, 'settings set' );
+        t.deepEqual( res.body[suite.props.index].settings.index_concurrency, custom_schema.settings.index_concurrency, 'settings set' );
         done();
       });
     });
@@ -63,7 +63,7 @@ module.exports.tests.default_schema = function(test, common) {
       }, function( err, res ){
         var expected = {};
         expected[suite.props.index] = { mappings: {} };
-        t.deepEqual( res, expected, 'default mappings' );
+        t.deepEqual( res.body, expected, 'default mappings' );
         done();
       });
     });
@@ -81,7 +81,7 @@ module.exports.tests.default_schema = function(test, common) {
       suite.client.indices.getSettings({
         index: suite.props.index
       }, function( err, res ){
-        t.deepEqual( res[suite.props.index].settings.index_concurrency, undefined, 'default settings' );
+        t.deepEqual( res.body[suite.props.index].settings.index_concurrency, undefined, 'default settings' );
         done();
       });
     });

--- a/test/custom_schema.js
+++ b/test/custom_schema.js
@@ -5,7 +5,7 @@ module.exports.tests = {};
 
 var custom_schema = {
   settings: { index: { refresh_interval: '-1' } },
-  mappings: { _doc: { properties: { name: { type: 'long' } } } }
+  mappings: { properties: { name: { type: 'long' } } }
 };
 
 // test creating index with custom schema
@@ -19,7 +19,6 @@ module.exports.tests.custom_schema = function(test, common) {
     suite.assert( function( done ){
       suite.client.indices.getMapping({
         index: suite.props.index,
-        type: '_doc'
       }, function( err, res ){
         t.deepEqual( res.body[suite.props.index].mappings, custom_schema.mappings, 'mappings set' );
         done();

--- a/test/example.js
+++ b/test/example.js
@@ -27,7 +27,7 @@ module.exports.tests.example = function(test, common) {
         index: doc.index,
         type: doc.type
       }, function( err, res ){
-        t.equal( res.count, 1, 'record count' );
+        t.equal( res.body.count, 1, 'record count' );
         done();
       });
     });
@@ -38,12 +38,12 @@ module.exports.tests.example = function(test, common) {
         type: doc.type,
         id: doc.id
       }, function( err, res ){
-        t.equal( res.found, true );
-        t.equal( res._id, doc.id );
-        t.equal( res._index, doc.index );
-        t.equal( res._type, doc.type );
-        t.deepEqual( res._source, doc.body );
-        t.equal( res._version, 1 );
+        const body = res.body;
+        t.equal( body.found, true );
+        t.equal( body._id, doc.id );
+        t.equal( body._index, doc.index );
+        t.deepEqual( res.body._source, doc.body );
+        t.equal( body._version, 1 );
         done();
       });
     });

--- a/test/example.js
+++ b/test/example.js
@@ -11,7 +11,6 @@ module.exports.tests.example = function(test, common) {
 
     var doc = {
       index: suite.props.index,
-      type: '_doc',
       id: '1',
       body: {
         foo: 'bar'
@@ -25,7 +24,6 @@ module.exports.tests.example = function(test, common) {
     suite.assert( function( done ){
       suite.client.count({
         index: doc.index,
-        type: doc.type
       }, function( err, res ){
         t.equal( res.body.count, 1, 'record count' );
         done();
@@ -35,7 +33,6 @@ module.exports.tests.example = function(test, common) {
     suite.assert( function( done ){
       suite.client.get({
         index: doc.index,
-        type: doc.type,
         id: doc.id
       }, function( err, res ){
         const body = res.body;


### PR DESCRIPTION
This replaces the deprecated [`elasticsearch`](https://www.npmjs.com/package/elasticsearch) package with it's successor [`@elastic/elasticsearch`](https://www.npmjs.com/package/@elastic/elasticsearch).

This is required by https://github.com/pelias/schema/pull/488

I *did* run the tests locally, but most of my confidence comes from it being used in my [elastic8 fork of pelias/schema](https://github.com/pelias/schema/pull/488).

See the mostly* successful CI run https://github.com/michaelkirk-pelias/schema/actions/runs/5274562778/jobs/9539146582

*CI is only failing because I don't have docker privs set up - the unit and integration tests are passing on es7 and es8.